### PR TITLE
#B01 Fixed bug with setup.bat not setting global server on .env

### DIFF
--- a/setup.bat
+++ b/setup.bat
@@ -4,7 +4,7 @@ MKDIR  .venv
 ECHO CREATING .env file
 ECHO DEVELOPMENT=1 >> .env
 ECHO SECRET_KEY="your_secret_key_here" >> .env
-ECHO SITE_NAME="localhost" >> .env
+ECHO SITE_NAME="*" >> .env
 ECHO Installing pipenv for development use
 pip install pipenv
 CLS


### PR DESCRIPTION
The setup.bat file for setting up environment for Windows IDE's was populating the SITE_NAME with 'localhost' which would not work on a local environment, as the IP would be 127.0.0.1. However, using this would conflict with those using Cloud based IDE like Gitpod.

Fixed error by changing the SITE_NAME="*" to set globally.