### PR TITLE
Additional PR in relation to User authentication ~ #83

### DIFF
--- a/accounts/models.py
+++ b/accounts/models.py
@@ -56,7 +56,7 @@ class Profile(models.Model):
             self.slack_display_name = self.user.profile.slack_display_name
             self.user_type = self.user.profile.user_type
             self.current_lms_module = self.user.profile.current_lms_module
-        logger.exception(KeyError)
+            logger.exception(str(KeyError))
         super(Profile, self).save(*args, **kwargs)
 
     def __str__(self):

--- a/accounts/models.py
+++ b/accounts/models.py
@@ -6,6 +6,10 @@ from django.db.models.signals import post_delete
 from allauth.account.signals import user_signed_up
 
 from .lists import USER_TYPES_CHOICES, LMS_MODULES_CHOICES
+import logging
+
+# Initialise instance of a logger to handle error logging
+logger = logging.getLogger(__name__)
 
 
 class Profile(models.Model):
@@ -52,7 +56,7 @@ class Profile(models.Model):
             self.slack_display_name = self.user.profile.slack_display_name
             self.user_type = self.user.profile.user_type
             self.current_lms_module = self.user.profile.current_lms_module
-
+        logger.exception(KeyError)
         super(Profile, self).save(*args, **kwargs)
 
     def __str__(self):

--- a/templates/includes/navbar.html
+++ b/templates/includes/navbar.html
@@ -39,11 +39,13 @@
                         My Account
                     </a>
                     <div class="dropdown-menu" aria-labelledby="navbarAccount">
-                        <a class="dropdown-item" href="#">Register</a>
-                        <a class="dropdown-item" href="#">Login</a>
-                        <div class="dropdown-divider"></div>
-                        <a class="dropdown-item" href="{% url 'profile' %}">My Profile</a>
-                        <a class="dropdown-item" href="#">Logout</a>
+                        {% if not user.is_authenticated %}
+                            <a class="dropdown-item" href="{%  url 'account_signup' %}">Register</a>
+                            <a class="dropdown-item" href="{% url 'account_login' %}">Login</a>
+                        {% else %}
+                            <a class="dropdown-item" href="{% url 'profile' %}">My Profile</a>
+                            <a class="dropdown-item" href="{% url 'account_logout' %}">Logout</a>
+                        {% endif %}
                     </div>
                 </li>
             </ul>


### PR DESCRIPTION
## Description

This PR adds the exception specific catch and logs that error using Django `logging`. Also, the Navbar has been altered to check for User Authentication whether logged in or otherwise and depending on same shows a different set of dropdown nav-items under the `My Account` main nav-item. 

## Related Issue

#M00. As a User, I would like to register an account. - Auxfuse #83 <--- This is an already merged PR with this PR coming in based off additional requirements outlayed in the comments of the previous merge.

## Testing

Exception testing not completed, however documentation was followed to ensure consistent normal code flow adherance. 

In terms of the navigation, the Navbar state was tested per User Authentication state:

So if User is not Logged in:

- Navbar shows My Account dropdown set of `Register` and `Login`

And if User is already Logged in:

- Navbar shows My Account dropdown set of `My Profile` and `Logout`

See gif depicting Navbar before login, and navbar after login....also quick frame inclusion of the register page returning the signup template.

![navbar](https://user-images.githubusercontent.com/48055438/96723164-24554900-13a6-11eb-983c-ecba16bc2dc7.gif)

## Does this introduce a breaking change

- [x] No
