### PR TITLE
#P04.2. Only display Hackathons where the org is CodeInstitute or where the `user.org == hackathon.org`

### DIFF
--- a/hackathon/templates/hackathon/hackathon_list.html
+++ b/hackathon/templates/hackathon/hackathon_list.html
@@ -5,14 +5,14 @@
     {% if hackathons %}
         <h2 class="p-orange text-center mb-4">Hackathons</h2>
         {% for hackathon in hackathons %}
-        {% if hackathon.organisation == 'Code Institute' or hackathon.organisation == user.organisation %}
-        {% if hackathon.status == 'published' or user == hackathon.created_by %}
-            {% if not hackathon.status == 'deleted' %}
-                {% include 'hackathon/includes/hackathon_card.html' %}
-                <hr>
+            {% if hackathon.organisation == 'Code Institute' or hackathon.organisation == user.organisation %}
+                {% if hackathon.status == 'published' or user == hackathon.created_by %}
+                    {% if not hackathon.status == 'deleted' %}
+                        {% include 'hackathon/includes/hackathon_card.html' %}
+                        <hr>
+                    {% endif %}
+                {% endif %}
             {% endif %}
-        {% endif %}
-        {% endif %}
         {% endfor %}
     {% else %}
         <h2 class="text-center">There aren't any Hackathons at the moment!</h2>

--- a/hackathon/templates/hackathon/hackathon_list.html
+++ b/hackathon/templates/hackathon/hackathon_list.html
@@ -5,11 +5,13 @@
     {% if hackathons %}
         <h2 class="p-orange text-center mb-4">Hackathons</h2>
         {% for hackathon in hackathons %}
+        {% if hackathon.organisation == 'Code Institute' or hackathon.organisation == user.organisation %}
         {% if hackathon.status == 'published' or user == hackathon.created_by %}
             {% if not hackathon.status == 'deleted' %}
                 {% include 'hackathon/includes/hackathon_card.html' %}
                 <hr>
             {% endif %}
+        {% endif %}
         {% endif %}
         {% endfor %}
     {% else %}


### PR DESCRIPTION

## Description
Added an if statement to check if the organisation is Code Institute or if the user.organisation == hackathon.organisation

<!-- Describe in a couple of sentences what this PR adds -->

## Pull request type
<!-- Please make sure you add the type to the name of the PR eg: feature/M06-as-a-user-i-love-pr -->
#P04.2. Only display Hackathons where the org is CodeInstitute or where the `user.org == hackathon.org`

## Testing
I created 3 Hackathons, one has organisation= "Code Institute", second has it blank and the third one has the organisation="Some organisation".
![admin](https://user-images.githubusercontent.com/67863074/97465237-c098c600-1939-11eb-85de-30cfad4462f1.png)

I changed my user organisation to "Some Organisation", so the Hackathons that were displayed were the one with organisation= "Code Institute" and organisation="Some organisation".
![hackathons](https://user-images.githubusercontent.com/67863074/97465414-eb831a00-1939-11eb-8951-d3be312b03e9.png)



## Does this introduce a breaking change

- [ ] Yes
- [x] No
<!-- Please fill in an xinside the [] for the correct one -->
