### PR TITLE
#A02/#A03 Adding new fields to create/edit hackathon form

### DIFF
--- a/hackathon/forms.py
+++ b/hackathon/forms.py
@@ -1,6 +1,8 @@
 from django import forms
-from .models import Hackathon
 
+from accounts.models import Organisation
+from .models import Hackathon
+from .lists import STATUS_TYPES_CHOICES, JUDGING_STATUS_CHOICES
 
 class HackathonForm(forms.ModelForm):
     """ A form to enable users to add hackathon events via the frontend site.
@@ -25,8 +27,7 @@ class HackathonForm(forms.ModelForm):
                 'rows': 3,
                 'placeholder': 'Tell us more about this event...'
             }
-        ),
-        required=True
+        )
     )
     theme = forms.CharField(
         label='Theme',
@@ -63,7 +64,27 @@ class HackathonForm(forms.ModelForm):
             }
         ),
     )
+    status = forms.CharField(
+        label="Status",
+        required=True,
+        widget=forms.Select(choices=STATUS_TYPES_CHOICES),
+    ),
+    judging_status = forms.CharField(
+        label="Judging Status",
+        required=True,
+        widget=forms.Select(choices=JUDGING_STATUS_CHOICES),
+    ),
+    organisation = forms.ModelChoiceField(
+        label="Organisation",
+        queryset=Organisation.objects.order_by('display_name'),
+    ),
 
     class Meta:
         model = Hackathon
-        fields = ['display_name', 'description', 'theme', 'start_date', 'end_date']
+        fields = ['display_name', 'description', 'theme', 'start_date',
+                  'end_date', 'status', 'judging_status', 'organisation',
+                  ]
+
+    def __init__(self, *args, **kwargs):
+        super(HackathonForm, self).__init__(*args, **kwargs)
+        self.fields['organisation'].empty_label = None

--- a/hackathon/templates/hackathon/create-event.html
+++ b/hackathon/templates/hackathon/create-event.html
@@ -34,6 +34,15 @@
         <div class="col-12">
           {{ form.theme|as_crispy_field }}
         </div>
+        <div class="col-12">
+          {{ form.organisation|as_crispy_field }}
+        </div>
+        <div class="col-12 col-md-6">
+          {{ form.status|as_crispy_field }}
+        </div>
+        <div class="col-12 col-md-6">
+          {{ form.judging_status|as_crispy_field }}
+        </div>
         <div class="col-12 col-md-6">
           {{ form.start_date|as_crispy_field }}
         </div>

--- a/hackathon/templates/hackathon/includes/hackathon_card.html
+++ b/hackathon/templates/hackathon/includes/hackathon_card.html
@@ -1,10 +1,11 @@
 <article class="card shadow hack-card">
   <div class="card-body">
-    <h5 class="p-orange card-title">{{ hackathon.display_name }}</h5>
+    <h5 class="p-orange card-title">{{ hackathon.display_name }} {% if user.user_type != 'participant' %}<span class="badge badge-secondary ml-2">{{hackathon.status}}</span> {% endif %}</h5>
     <p class="card-subtitle mb-2 text-muted"><i class="far fa-calendar-alt p-2"></i> {{ hackathon.start_date }} - {{ hackathon.end_date }}</p>
-    <p class="card-text"><i class="fas fa-info-circle p-2"></i> {{ hackathon.description }}</p>
-    {% if hackathon.organiser %}
-      <p><span class="pr-2">Organiser:</span> <a href="#" class="card-link"><span class="dark-text">{{ hackathon.organiser }}</span></a></p>
+    <p class="card-subtitle mb-2 text-muted"><i class="fas fa-building p-2"></i> Organised for {{ hackathon.organisation }}</p>
+    {% if user.user_type != 'participant' %}
+    <p class="card-subtitle mb-2">
+      <i class="fas fa-users p-2"></i>Participants: {{ hackathon.participants.all|length }} / Teams: {{ hackathon.teams.all|length }}</p>
     {% endif %}
     <a href="{% url 'hackathon:view_hackathon' hackathon.id %}" class="btn btn-ci mr-3">Read More</a>
 

--- a/hackathon/views.py
+++ b/hackathon/views.py
@@ -156,7 +156,6 @@ def create_hackathon(request):
 
     else:
         form = HackathonForm(request.POST)
-        
         # Convert start and end date strings to datetime and validate
         start_date = datetime.strptime(
             request.POST.get('start_date'), '%d/%m/%Y %H:%M')

--- a/hackathon/views.py
+++ b/hackathon/views.py
@@ -150,12 +150,13 @@ def create_hackathon(request):
             return redirect("hackathon:hackathon-list")
 
         template = "hackathon/create-event.html"
-        form = HackathonForm()
+        form = HackathonForm(initial={'organisation': 1})
 
         return render(request, template, {"form": form})
 
     else:
         form = HackathonForm(request.POST)
+        
         # Convert start and end date strings to datetime and validate
         start_date = datetime.strptime(
             request.POST.get('start_date'), '%d/%m/%Y %H:%M')
@@ -178,6 +179,7 @@ def create_hackathon(request):
         # Submit form and save record
         if form.is_valid():
             form.instance.created_by = request.user
+            form.instance.organiser = request.user
             form.save()
             messages.success(
                 request, 'Thanks for submitting a new Hackathon event!')

--- a/home/templates/home/index.html
+++ b/home/templates/home/index.html
@@ -5,39 +5,37 @@
 
     <div class="row landing-page">
         <div class = "col-12 col-sm-12  col-md-12 col-lg-6 " id="accordion-wrapper">
+            {% if hackathons %}
             <h1 class="text-center mt-4">Upcoming Hackathons</h1>
             <div class="accordion" id="accordion-upcoming-hackathons">
-                {% if hackathons %}
-                    {% for hackathon in hackathons %}
-                        {% if hackathon.status == 'published' or user == hackathon.created_by %}
-                            {% if hackathon.organisation.id == 1 or hackathon.organisation == user.organisation %}
-                                {% if not hackathon.status == 'deleted' %}
-                                <div class="card">
-                                    <div class="card-header" id="heading-{{ hackathon.id }}">
-                                        <span class="btn btn-link" type="button" data-toggle="collapse" data-target="#collapse-{{ hackathon.id }}" aria-expanded="true" aria-controls="collapse-{{ hackathon.id }}">
-                                            <h5 class="card-title"><i class="fas fa-caret-down"></i> {{ hackathon.display_name }}</h5>
-                                        </span>
-                                    </div>
-                                    <div id="collapse-{{ hackathon.id }}" class="collapse" aria-labelledby="heading-{{ hackathon.id }}" data-parent="#accordion-upcoming-hackathons">
-                                        <div class="card-body">
-                                        
-                                            <h6 class="card-subtitle mb-2 text-muted"><span class="drk-txt-hkth">Start: </span>{{ hackathon.start_date }} - <span class="drk-txt-hkth">End: </span>{{ hackathon.end_date }}</h6>
-                                                <p class="card-text">{{ hackathon.description }}</p>
-                                            {% if hackathon.organiser %}
-                                            <p><span class="drk-txt-hkth">Organiser: </span><a href="#" class="p-blue card-link">{{ hackathon.organiser }}</a></p>
-                                            {% endif %}
-                                            <a href="{% url 'hackathon:view_hackathon' hackathon.id %}" class="btn btn-ci mr-3">Read More</a>
-                                        </div>
-                                    </div>
+            {% for hackathon in hackathons %}
+                {% if hackathon.status == 'published' %}
+                    {% if hackathon.organisation.id == 1 or hackathon.organisation == user.organisation %}
+                        {% if not hackathon.status == 'deleted' %}
+                        <div class="card">
+                            <div class="card-header" id="heading-{{ hackathon.id }}">
+                                <span class="btn btn-link" type="button" data-toggle="collapse" data-target="#collapse-{{ hackathon.id }}" aria-expanded="true" aria-controls="collapse-{{ hackathon.id }}">
+                                    <h5 class="card-title"><i class="fas fa-caret-down"></i> {{ hackathon.display_name }}</h5>
+                                </span>
+                            </div>
+                            <div id="collapse-{{ hackathon.id }}" class="collapse" aria-labelledby="heading-{{ hackathon.id }}" data-parent="#accordion-upcoming-hackathons">
+                                <div class="card-body">
+                                    <h6 class="card-subtitle mb-2 text-muted"><span class="drk-txt-hkth">Start: </span>{{ hackathon.start_date }} - <span class="drk-txt-hkth">End: </span>{{ hackathon.end_date }}</h6>
+                                        <p class="card-text">{{ hackathon.description }}</p>
+                                    {% if hackathon.organiser %}
+                                    <p><span class="drk-txt-hkth">Organiser: </span><a href="#" class="p-blue card-link">{{ hackathon.organiser }}</a></p>
+                                    {% endif %}
+                                    <a href="{% url 'hackathon:view_hackathon' hackathon.id %}" class="btn btn-ci mr-3">Read More</a>
                                 </div>
                             </div>
-                            {% endif %}
+                        </div>
                         {% endif %}
                     {% endif %}
-                {% endfor %}
-                {% else %}
-                <h2 class="text-center">There aren't any Hackathons at the moment!</h2>
                 {% endif %}
+            {% endfor %}
+            {% else %}
+            <h2 class="text-center">There aren't any Hackathons at the moment!</h2>
+            {% endif %}
             </div>
             <div class="project-list">
                 <ol class="list">Project Portfolio
@@ -48,7 +46,6 @@
             </div>
         </div>
         <div class = "col-12 col-sm-12 col-md-12 col-lg-6">
-            
             <div class="card mt-4">
                 <img class="card-img-top" src="{% static 'img/ci-hacking-new-normal--square.png' %}" alt="Code Institute Hackathon Logo">
             </div>
@@ -84,6 +81,5 @@
             </div>
         </div>
     </div>
-
 
 {% endblock %}


### PR DESCRIPTION
## Description
Updating the create-event form to be able to set organisation, status and juding_status when creating or editing a Hackathon. 
Also set the organiser to be the `request.user` in the view which was missing.

## Pull request type
- [ ] #M01 (Miscellaneous User Story #01)
- [ ] #P02 (Participant User Story #02)
- [ ] #S03 (Staff User Story #03)
- [ ] #A04 (Admin User Story #04)
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Related Issue
#40 
#41 

## Testing
Testing is still broken, but will be fixed as part of https://github.com/Code-Institute-Community/ci-hackathon-app/pull/122

## Screenshots
![image](https://user-images.githubusercontent.com/31205982/103250488-fecb5980-496b-11eb-9303-71874b2acbb2.png)
![image](https://user-images.githubusercontent.com/31205982/103250490-025ee080-496c-11eb-9ac2-5c387eed3727.png)
