### PR TITLE
#M28. Add management command to sync Slack information with user account on Hackathon platform

### DIFF
--- a/accounts/helpers.py
+++ b/accounts/helpers.py
@@ -1,0 +1,67 @@
+import logging
+import requests
+import time
+
+from django.conf import settings
+
+from accounts.models import CustomUser as User
+
+USER_DETAIL_URL = 'https://slack.com/api/users.info'
+
+DEFAULT_KEYS = {
+    'profile.display_name_normalized': 'slack_display_name',
+    'profile.real_name': 'full_name',
+    'profile.first_name': 'first_name',
+    'profile.last_name': 'last_name',
+    'profile.image_original': 'profile_image',
+    'profile.title': 'about',
+    'tz': 'timezone',
+    'email': 'email'
+}
+
+logger = logging.getLogger(__name__)
+
+
+def update_value(user, field, value):
+    """ Updates a User's field value if a value is given """
+    if not value:
+        return
+
+    setattr(user, field, value)
+    user.save()
+
+
+def get_keys_and_update_user(data, keys, user):
+    """ Gets the specified keys from the data and updates the User """
+    if keys:
+        specified_keys = {
+            key: value for key, value in DEFAULT_KEYS.items()
+            if value in keys}
+    else:
+        specified_keys = DEFAULT_KEYS
+
+    for key, field in specified_keys.items():
+        _k = key.split('.')
+        value = (data.get(key) if len(_k) == 1
+                 else data.get(_k[0], {}).get(_k[1]))
+
+        update_value(user, field, value)
+
+
+def sync_slack_users(users, keys, interval):
+    """ Sync the profile information from Slack with the the hackathon app """
+    if users:
+        users = User.objects.filter(username__in=users)
+    else:
+        users = User.objects.all()
+
+    for user in users:
+        user_id = user.username.split('_')[0]
+        user_info = requests.get(
+            USER_DETAIL_URL,
+            params={'token': settings.SLACK_BOT_TOKEN, 'user': user_id})
+        if user_info.status_code != 200:
+            logger.info(f'User {user_id} not found.')
+        get_keys_and_update_user(user_info.json()['user'], keys, user)
+        logger.info(f'User {user_id} updated successfully.')
+        time.sleep(interval)

--- a/accounts/management/commands/sync_slack.py
+++ b/accounts/management/commands/sync_slack.py
@@ -1,0 +1,22 @@
+from django.core.management.base import BaseCommand
+
+from accounts.helpers import sync_slack_users
+
+
+class Command(BaseCommand):
+    help = 'Syncs all or specified users with the information on Slack'
+
+    def add_arguments(self, parser):
+        parser.add_argument('-u', '--users', nargs='+',
+                            help='Set users to be synced',)
+        parser.add_argument('-k', '--keys', nargs='+',
+                            help='Set keys to be updated',)
+        parser.add_argument('-i', '--interval', type=float,
+                            help='Set the sleep interval in between requests',)
+
+    def handle(self, *args, **kwargs):
+        users = kwargs.get('users')
+        keys = kwargs.get('keys')
+        interval = kwargs.get('interval', 0.0) or 0.0
+
+        sync_slack_users(users, keys, interval)

--- a/main/settings.py
+++ b/main/settings.py
@@ -202,7 +202,7 @@ LOGGING = {
     },
     'root': {
         'handlers': ['console'],
-        'level': 'WARNING',
+        'level': 'INFO',
     },
 }
 


### PR DESCRIPTION
## Description
Adding a management command to sync Slack information with Hackathon platform account.

## Pull request type
<!-- Please make sure you add the type to the name of the PR eg: feature/M06-as-a-user-i-love-pr -->
- [x] #M01 (Miscellaneous User Story #01)
- [ ] #P02 (Participant User Story #02)
- [ ] #S03 (Staff User Story #03)
- [ ] #A04 (Admin User Story #04)
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Related Issue
#255
