### PR TITLE
Bugfix: Only display winning projects on the Hackathon home page once the hackathon finished.

### DIFF
--- a/home/views.py
+++ b/home/views.py
@@ -43,7 +43,8 @@ def home(request):
         organisation=1).order_by('-start_date')
 
     winning_awards = HackAward.objects.filter(
-        hack_award_category__ranking=1).order_by('-hackathon__start_date')
+        hack_award_category__ranking=1, hackathon__status='finished'
+            ).order_by('-hackathon__start_date')
     winning_showcases = [award.winning_project.get_showcase()
                          for award in winning_awards
                          if (award.winning_project


### PR DESCRIPTION
## Description
Filter awards displayed on the home page by the hackathon status "finished" only.

## Pull request type
<!-- Please make sure you add the type to the name of the PR eg: feature/M06-as-a-user-i-love-pr -->
- [ ] #M01 (Miscellaneous User Story #01)
- [ ] #P02 (Participant User Story #02)
- [ ] #S03 (Staff User Story #03)
- [ ] #A04 (Admin User Story #04)
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Related Issue
#260
